### PR TITLE
Don't rpm --import https://packages.icinga.com/icinga.key

### DIFF
--- a/Amazon-Linux.md
+++ b/Amazon-Linux.md
@@ -19,7 +19,6 @@ All packages we provide are signed with the following [key](https://packages.ici
 Here’s how to add the official release repository:
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 curl https://packages.icinga.com/subscription/amazon/ICINGA-release.repo -o /etc/yum.repos.d/ICINGA-release.repo
 ```
 

--- a/CentOS.md
+++ b/CentOS.md
@@ -12,7 +12,6 @@ All packages we provide are signed with the following [key](https://packages.ici
 Here’s how to add the official release repository:
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 curl https://packages.icinga.com/centos/ICINGA-release.repo -o /etc/yum.repos.d/ICINGA-release.repo
 ```
 

--- a/Fedora.md
+++ b/Fedora.md
@@ -12,7 +12,6 @@ All packages we provide are signed with the following [key](https://packages.ici
 Here’s how to add the official release repository:
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 dnf install -y 'dnf-command(config-manager)'
 dnf config-manager --add-repo https://packages.icinga.com/fedora/$(. /etc/os-release; echo "$VERSION_ID")/release
 ```

--- a/RHEL.md
+++ b/RHEL.md
@@ -19,7 +19,6 @@ All packages we provide are signed with the following [key](https://packages.ici
 Here’s how to add the official release repository:
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 curl https://packages.icinga.com/subscription/rhel/ICINGA-release.repo -o /etc/yum.repos.d/ICINGA-release.repo
 ```
 

--- a/SLES.md
+++ b/SLES.md
@@ -19,8 +19,6 @@ All packages we provide are signed with the following [key](https://packages.ici
 Here’s how to add the official release repository:
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
-
 zypper ar -r https://packages.icinga.com/subscription/sles/$releasever/release/ icinga-stable-release
 ```
 

--- a/openSUSE.md
+++ b/openSUSE.md
@@ -12,7 +12,6 @@ All packages we provide are signed with the following [key](https://packages.ici
 Here’s how to add the official release repository:
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 zypper ar -r https://packages.icinga.com/openSUSE/ICINGA-release.repo
 ```
 


### PR DESCRIPTION
just like on packages.icinga.com and for the same security reasons we don't use apt-key add anymore for: https://blog.cloudflare.com/dont-use-apt-key

Our repos already reference https://packages.icinga.com/icinga.key and both RPM distro families properly handle that.