### PR TITLE
Set OS variables for later use

### DIFF
--- a/Amazon-Linux.md
+++ b/Amazon-Linux.md
@@ -37,4 +37,6 @@ Use your distribution's package manager to install the `<!-- {{ package }} -->` 
     ```bash
     yum install <!-- {{ package }} -->
     ```
+
+<!-- {% set amazon_linux = True %} -->
 <!-- {% include "02-Installation.md" %} -->

--- a/Debian.md
+++ b/Debian.md
@@ -39,4 +39,8 @@ Use your distribution's package manager to install the `<!-- {{ package }} -->` 
 ```bash
 apt install <!-- {{ package }} -->
 ```
+
+<!-- {% if not raspberry_pi_os %} -->
+<!-- {% set debian = True %} -->
+<!-- {% endif %} -->
 <!-- {% include "02-Installation.md" %} -->

--- a/Fedora.md
+++ b/Fedora.md
@@ -23,4 +23,6 @@ Use your distribution's package manager to install the `<!-- {{ package }} -->` 
 ```bash
 dnf install <!-- {{ package }} -->
 ```
+
+<!-- {% set fedora = True %} -->
 <!-- {% include "02-Installation.md" %} -->

--- a/RHEL.md
+++ b/RHEL.md
@@ -30,4 +30,5 @@ Use your distribution's package manager to install the `<!-- {{ package }} -->` 
 dnf install <!-- {{ package }} -->
 ```
 
+<!-- {% set rhel = True %} -->
 <!-- {% include "02-Installation.md" %} -->

--- a/Raspberry-Pi-OS.md
+++ b/Raspberry-Pi-OS.md
@@ -1,4 +1,5 @@
 # Installing <!-- {{ product }} --> on Raspberry Pi OS (64-bit only)
 
+<!-- {% set raspberry_pi_os = True %} -->
 <!-- {% set disable_header = True %} -->
 <!-- {% include "02-Installation.md.d/Debian.md" %} -->

--- a/SLES.md
+++ b/SLES.md
@@ -29,4 +29,6 @@ Use your distribution's package manager to install the `<!-- {{ package }} -->` 
 ```bash
 zypper install <!-- {{ package }} -->
 ```
+
+<!-- {% set sles = True %} -->
 <!-- {% include "02-Installation.md" %} -->

--- a/Ubuntu.md
+++ b/Ubuntu.md
@@ -37,4 +37,6 @@ Use your distribution's package manager to install the `<!-- {{ package }} -->` 
 ```bash
 apt install <!-- {{ package }} -->
 ```
+
+<!-- {% set ubuntu = True %} -->
 <!-- {% include "02-Installation.md" %} -->

--- a/openSUSE.md
+++ b/openSUSE.md
@@ -22,4 +22,6 @@ Use your distribution's package manager to install the `<!-- {{ package }} -->` 
 ```bash
 zypper install <!-- {{ package }} -->
 ```
+
+<!-- {% set opensuse = True %} -->
 <!-- {% include "02-Installation.md" %} -->


### PR DESCRIPTION
In the actual installation docs which are included, it may be necessary to differentiate between individual steps depending on the operating system.