### PR TITLE
Fedora: Add Repo independent of DNF 4/5

### DIFF
--- a/Fedora.md
+++ b/Fedora.md
@@ -12,8 +12,8 @@ All packages we provide are signed with the following [key](https://packages.ici
 Here’s how to add the official release repository:
 
 ```bash
-dnf install -y 'dnf-command(config-manager)'
-dnf config-manager --add-repo https://packages.icinga.com/fedora/$(. /etc/os-release; echo "$VERSION_ID")/release
+rpm --import https://packages.icinga.com/icinga.key
+curl -o /etc/yum.repos.d/ICINGA-release.repo https://packages.icinga.com/fedora/ICINGA-release.repo
 ```
 
 ## Installing the Package


### PR DESCRIPTION
With Fedora 41, DNF was upgraded to version 5, breaking the command line API of "dnf config-manager"[^0]. Unfortunately, DNF 5's addrepo does not work with a simple URL anymore, but requires to construct a .repo file.

Furthermore, no information about trusting the Icinga signing key was available, resulting in one being unable to install packages. This was already the case for Fedora 40, still using DNF 4.

This change is identical to another one in the Icinga 2 repo[^1].

[^0]: https://docs.fedoraproject.org/en-US/quick-docs/adding-or-removing-software-repositories-in-fedora/#_adding_repositories
[^1]: Icinga/icinga2#10479